### PR TITLE
✨ Add yarn script to build iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "flow": "flow check",
     "format": "prettier --write '{*,{__mocks__,__tests__,app}/**/*}.js'",
     "jest": "jest --watch",
+    "run-ios": "react-native run-ios --simulator='iPhone X' --scheme ApprenticeProgress",
     "start": "node node_modules/react-native/local-cli/cli.js start --reset-cache",
     "test": "yarn format && lint . && jest && flow",
     "storybook": "storybook start -p 7007"


### PR DESCRIPTION
Xcode has decided to start enforcing caps in the name of schemes. So
when `react-native run-ios` was called, the scheme apprenticeprogress
was looked for rather than ApprenticeProgress.

Rather than dealing with this annoyance closer to the root (which could
have side effects), I’m adding this yarn command which specifies the
scheme name with capitals - and to call an iPhone X while I'm at it.